### PR TITLE
Features, bug fixes, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
-EC2
-===
+EC2 Operator
+============
+
+Automatically starts and stops Amazon EC2 instances based on auto:start and auto:stop tags in cron format. Designed to
+run simply without excessive configuration, all options can be configured via command line or instance tags.
+
+It will also check elastic load balancers when starting instances and de-register then re-register the instance against
+any load balancers to make sure that the instances comes online in the elastic load balancer in a reasonable time frame.
+
+Example
+-------
+
+Start an instance at 15:00 UTC Monday through Friday and stop it at 04:00 UTC every day.
+
+**auto:start** 0 15 * * 1-5
+**auto:stop**  0 4 * * *
+
+Usage
+-----
+
+    usage: ec2_operator.py [-h] [-l {debug,info,warning,error,critical}]
+                           [-f LOGFILE] [-m LOGMAX] [-b LOGBACKUPS] [-s STARTWIN]
+                           [-t STOPWIN] [-n]
+
+    Automatically stop and start ec2 instances based on tags.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -l {debug,info,warning,error,critical}, --loglevel {debug,info,warning,error,critical}
+                            Set logging level (default: None)
+      -f LOGFILE, --logfile LOGFILE
+                            Enable logging to filename (default: None)
+      -m LOGMAX, --logmax LOGMAX
+                            Maximum log size before rotation in megabytes
+                            (default: 1)
+      -b LOGBACKUPS, --logbackups LOGBACKUPS
+                            Maximum number of rotated logs to keep (default: 10)
+      -s STARTWIN, --startwin STARTWIN
+                            How many minutes early an instance may be started
+                            (default: 10)
+      -t STOPWIN, --stopwin STOPWIN
+                            How many minutes after an instance will be stopped
+                            (default: 60)
+      -n, --dry-run         trial run with no instance stops or starts (default:
+                            False)
+
+Example
+--------
+
+ec2_operator.py -l debug -f /var/log/ec2_operator.log -m 5 -b 10 -s 5 -t 30
+
+Runs with debug level log output to /var/log/ec2_operator. Log files are rotated at 5 megabytes and up to 10 log
+files are kept. Instances will be started if they are scheduled to start within 5 minutes of a run. They will be
+stopped if the they are found running within 60 minutes of a run.
+
+An instance will not be restarted if its launch time is after the beginning of the shutdown window. For example, if
+the shutdown window is 01:00 and someone restarted the instance at 01:05, a run at 01:10 would not start that instance
+back up.
+
+The stop window is 60 minutes by default to give ample room to make sure the instance is shut down.
+
+The start window is 10 minutes in order to give several chances to start the instance if run on a */5 schedule as well
+as to give the instance plenty of time to start up before it is needed.
+
+
+Scheduling
+----------
+
+This is typically executed via cron. The interval needs to make sense according to the start and stop windows used.
+Running every 5 minutes with the default windows is the normal use case.
+
+    */5 * * * * /usr/local/bin/ec2_operator.py --loglevel info --logfile /var/log/ec2-operator/ec2-operator.log
+
+
+Permissions
+-----------
+
+Requires either an instance role or AWS credentials configured with the following permissions:
+
+    {
+       "Statement":[
+          {
+             "Action":[
+                "ec2:DescribeInstances",
+                "ec2:StartInstances",
+                "ec2:StopInstances",
+                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+             ],
+             "Effect":"Allow",
+             "Resource":"*"
+          }
+       ]
+    }

--- a/TestEc2Operator.py
+++ b/TestEc2Operator.py
@@ -19,7 +19,18 @@ class TestEc2Operator(TestCase):
         except ValueError:
             pass
         except Exception as e:
-            self.fail("Unexpected exception thrown: " + e.message)
+            self.fail("Unexpected exception thrown: " + e)
+        else:
+            self.fail("Expected exception not thrown")
+
+        try:
+            ec2_operator.time_to_stop("badcron 0 6 * * *",
+                                      self.get_pytz_utc_datetime("Jan 15 2015 00:00"),
+                                      self.get_pytz_utc_datetime("Jan 01 2015 00:00"))
+        except KeyError:
+            pass
+        except Exception as e:
+            self.fail("Unexpected exception thrown: " + e)
         else:
             self.fail("Expected exception not thrown")
 

--- a/TestEc2Operator.py
+++ b/TestEc2Operator.py
@@ -1,0 +1,135 @@
+from unittest import TestCase
+import ec2_operator
+import pytz
+from dateutil import parser
+
+
+class TestEc2Operator(TestCase):
+    # croniter requires a tzinfo object that supports localize so simple parsing of the timezone won't work
+    def get_pytz_utc_datetime(self, time_string):
+        return parser.parse(time_string).replace(tzinfo=pytz.utc)
+
+    def test_bad_cron(self):
+
+        try:
+            ec2_operator.time_to_stop("badcron",
+                                      self.get_pytz_utc_datetime("Jan 15 2015 00:00"),
+                                      self.get_pytz_utc_datetime("Jan 01 2015 00:00"))
+
+        except ValueError:
+            pass
+        except Exception as e:
+            self.fail("Unexpected exception thrown: " + e.message)
+        else:
+            self.fail("Expected exception not thrown")
+
+    # Check stop cron time: (window_start <= cron_time <= now)
+    def test_time_to_action_stop(self):
+
+        old_launch_time = self.get_pytz_utc_datetime("Jan 01 2012 00:00:00")
+
+        # Stop at 01:00 and it's 00:00 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:00"), old_launch_time),
+            "Stop well before window")
+
+        # Stop at 01:00 and it's 00:59 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:59"), old_launch_time),
+            "Stop one minute before window")
+
+        # Stop at 01:00 and it's 01:00 UTC
+        self.assertTrue(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:00"), old_launch_time),
+            "Stop at exact window start")
+
+        # Stop at 01:00 and it's 01:00 MST
+        self.assertTrue(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:00").replace(
+                tzinfo=pytz.timezone('MST')), old_launch_time), "Stop at exact window start MST")
+
+        # Stop at 01:00 and it's 01:01 UTC
+        self.assertTrue(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:01"), old_launch_time),
+            "Stop one minute inside window")
+
+        # Stop at 01:00 and it's 01:15 UTC
+        self.assertTrue(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:15"), old_launch_time),
+            "Stop inside window")
+
+        # Stop at 01:00 and it's 01:15 UTC, but the instance was restarted at 00:59 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:15"),
+                                      self.get_pytz_utc_datetime("Jan 15 2015 00:59")),
+            "Stop inside window with recent restart #1")
+
+        # Stop at 01:00 and it's 01:15 MST, but the instance was restarted at 00:59 MST
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:15").replace(
+                tzinfo=pytz.timezone('MST')),
+                self.get_pytz_utc_datetime("Jan 15 2015 00:59").replace(
+                tzinfo=pytz.timezone('MST'))), "Stop inside window with recent restart #2")
+
+        # Stop at 01:00 and it's 01:15 UTC, but the instance was restarted at 01:05 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:15"),
+                                      self.get_pytz_utc_datetime("Jan 15 2015 01:05")),
+            "Stop inside window with recent restart #3")
+
+        # Stop at 01:00 and it's 01:30 UTC
+        self.assertTrue(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:30"), old_launch_time),
+            "Stop at exact window end")
+
+        # Stop at 01:00 and it's 02:01 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 02:01"), old_launch_time),
+            "Stop one minute past window")
+
+        # Stop at 01:00 and it's 05:00 UTC
+        self.assertFalse(
+            ec2_operator.time_to_stop("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 05:00"), old_launch_time),
+            "Stop well past window")
+
+    # Check start cron time: (now <= cron_time <= window_end)
+    def test_time_to_action_start(self):
+        # Start at 01:00 and it's 00:00 UTC
+        self.assertFalse(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 15:00")),
+            "Start well before window")
+
+        # Start at 01:00 and it's 00:29 UTC
+        self.assertFalse(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:29")),
+            "Start one minute before window")
+
+        # Start at 01:00 and it's 00:50 UTC
+        self.assertTrue(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:50")),
+            "Start at exact window start")
+
+        # Start at 01:00 and it's 00:51 UTC
+        self.assertTrue(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:51")),
+            "Start one minute inside window")
+
+        # Start at 01:00 and it's 00:55 UTC
+        self.assertTrue(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 00:55")),
+            "Start inside window")
+
+        # Start at 01:00 and it's 01:00 UTC
+        self.assertTrue(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:00")),
+            "Start at exact window end")
+
+        # Start at 01:00 and it's 01:01 UTC
+        self.assertFalse(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 01:01")),
+            "Start one minute past window")
+
+        # Start at 01:00 and it's 05:00 UTC
+        self.assertFalse(
+            ec2_operator.time_to_start("0 1 * * *", self.get_pytz_utc_datetime("Jan 15 2015 05:00")),
+            "Start well past window")

--- a/ec2_operator.json
+++ b/ec2_operator.json
@@ -157,7 +157,11 @@
                   "Action": [
 				    "ec2:DescribeInstances",
                     "ec2:StartInstances",
-                    "ec2:StopInstances"
+                    "ec2:StopInstances",
+                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                    "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                    "elasticloadbalancing:DescribeLoadBalancers",
+                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
 				  ], 
                   "Effect": "Allow", 
                   "Resource": "*"

--- a/ec2_operator.py
+++ b/ec2_operator.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
                             if start_sched and state == "stopped" and time_to_start(start_sched, now):
                                 logger.info("Starting instance: %s (%s)", name, instance.id)
                                 start_list.append(instance.id)
-                        except ValueError as ve:
+                        except (ValueError, KeyError) as ve:
                             logger.error("Invalid auto:start tag on instance %s (%s): '%s' (%s)", name, instance.id, start_sched, ve)
 
                         try:
@@ -110,7 +110,7 @@ if __name__ == "__main__":
                             if stop_sched and state == "running" and time_to_stop(stop_sched, now, launch_time):
                                 logger.info("Stopping instance: %s (%s)", name, instance.id)
                                 stop_list.append(instance.id)
-                        except ValueError as ve:
+                        except (ValueError, KeyError) as ve:
                             logger.error("Invalid auto:stop tag on instance %s (%s): '%s' (%s)", name, instance.id, stop_sched, ve)
 
                 # start instances

--- a/ec2_operator.py
+++ b/ec2_operator.py
@@ -1,66 +1,143 @@
 #!/usr/bin/python
 
 import boto.ec2
+import boto.ec2.elb
 import croniter
 import datetime
+from time import sleep
+import dateutil.parser
+import pytz
+import argparse
+import logging
+import logging.handlers
 
-# return true if the cron schedule falls between now and now+seconds
-def time_to_action(sched, now, seconds):
-  try:
-    cron = croniter.croniter(sched, now)
-    d1 = now + datetime.timedelta(0, seconds)
-    if (seconds > 0):
-      d2 = cron.get_next(datetime.datetime)
-      ret = (now < d2 and d2 < d1)
+logger = logging.getLogger(__name__)
+
+# Default window sizes to avoid missing a stop/start if a cron run misses or is off substantially from script runs.
+# Instances will not be stopped again if they have been restarted since the beginning of the current stop period
+start_window_size_minutes = 10
+stop_window_size_minutes = 60
+
+
+def time_to_start(schedule, now):
+    # Round 'now' down and subtract one second so if the script is called at e.g. 05:00 and auto:start is 05:00,
+    # croniter gives us this 05:00 run instead of the next. Otherwise, if this runs at 5:00 instances wouldn't start
+    cron = croniter.croniter(schedule, now - datetime.timedelta(0, now.second + 1))
+    window_end = now + datetime.timedelta(0, start_window_size_minutes * 60)
+    cron_time = cron.get_next(datetime.datetime)
+    logger.debug("now <= cron_time <= window_end = %s < %s < %s", now, window_end, cron_time)
+    return (now <= cron_time <= window_end)
+
+
+def time_to_stop(schedule, now, launch_time):
+    # Round 'now' up to the next minute so if the script is called at e.g. 05:00 and auto:stop is 05:00, croniter
+    # gives us this 05:00 run instead of the last one, and we shut down the instance on time.
+    cron = croniter.croniter(schedule, now + datetime.timedelta(0, 60 - now.second))
+    window_start = now - datetime.timedelta(0, stop_window_size_minutes * 60)
+    cron_time = cron.get_prev(datetime.datetime)
+    logger.debug("window_start <= cron_time <= now = %s < %s < %s", window_start, cron_time, now)
+    return (launch_time < window_start <= cron_time <= now)
+
+if __name__ == "__main__":
+
+    now = datetime.datetime.now(pytz.utc)
+
+    parser = argparse.ArgumentParser(description='Automatically stop and start ec2 instances based on tags.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-l", "--loglevel", help="Set logging level", type=str.lower,
+                        choices=['debug', 'info', 'warning', 'error', 'critical'])
+    parser.add_argument("-f", "--logfile", help="Enable logging to filename")
+    parser.add_argument("-m", "--logmax", help="Maximum log size before rotation in megabytes", default=1, type=int)
+    parser.add_argument("-b", "--logbackups", help="Maximum number of rotated logs to keep", default=10, type=int)
+    parser.add_argument("-s", "--startwin", help="How many minutes early an instance may be started", default=start_window_size_minutes, type=int)
+    parser.add_argument("-t", "--stopwin", help="How many minutes after an instance will be stopped", default=stop_window_size_minutes, type=int)
+    parser.add_argument("-n", "--dry-run", help="trial run with no instance stops or starts", action="store_true")
+    args = parser.parse_args()
+
+    if args.loglevel:
+        log_level = getattr(logging, args.loglevel.upper(), None)
     else:
-      d2 = cron.get_prev(datetime.datetime)
-      ret = (d1 < d2 and d2 < now)
-    print "now %s" % now
-    print "d1 %s" % d1
-    print "d2 %s" % d2
-  except:
-    ret = False
-  print "time_to_action %s" % ret
-  return ret
+        log_level = logging.INFO
 
-now = datetime.datetime.now()
+    log_format = "%(asctime)s %(levelname)s %(message)s"
 
-# go through all regions
-for region in boto.ec2.regions():
-  try:
-    conn=boto.ec2.connect_to_region(region.name)
-    reservations = conn.get_all_instances()
-    start_list = []
-    stop_list = []
-    for res in reservations:
-      for inst in res.instances:
-        name = inst.tags['Name'] if 'Name' in inst.tags else 'Unknown'
-        state = inst.state
+    if args.logfile:
+        file_handler = logging.handlers.RotatingFileHandler(filename=args.logfile, maxBytes=args.logmax * 1024 * 1024, backupCount=args.logbackups)
+        file_handler.setFormatter(logging.Formatter(log_format))
+        logger.addHandler(file_handler)
+    else:
+        logging.basicConfig(format=log_format)
 
-        # check auto:start and auto:stop tags
-        start_sched = inst.tags['auto:start'] if 'auto:start' in inst.tags else None
-        stop_sched = inst.tags['auto:stop'] if 'auto:stop' in inst.tags else None
+    logger.setLevel(log_level)
 
-        print "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (region.name, name, inst.id, inst.instance_type, inst.launch_time, state, start_sched, stop_sched, inst.tags)
+    logger.info("Run starting.")
 
-        # queue up instances that have the start time falls between now and the next 30 minutes
-        if start_sched != None and state == "stopped" and time_to_action(start_sched, now, 31 * 60):
-          start_list.append(inst.id)
+    # go through all regions
+    instances = 0
+    for region in boto.ec2.regions():
+        if region.name not in ['cn-north-1', 'us-gov-west-1']:
+            try:
+                logger.debug("Connecting to region: %s", region.name)
+                conn = boto.ec2.connect_to_region(region.name)
+                reservations = conn.get_all_instances()
+                start_list = []
+                stop_list = []
+                slept = False
+                for reservation in reservations:
+                    for instance in reservation.instances:
+                        instances += 1
+                        name = instance.tags['Name'] if 'Name' in instance.tags else 'Unknown'
+                        state = instance.state
 
-        # queue up instances that have the stop time falls between 30 minutes ago and now
-        if stop_sched != None and state == "running" and time_to_action(stop_sched, now, 31 * -60):
-          stop_list.append(inst.id)
+                        # check auto:start and auto:stop tags
+                        start_sched = instance.tags['auto:start'] if 'auto:start' in instance.tags else None
+                        stop_sched = instance.tags['auto:stop'] if 'auto:stop' in instance.tags else None
 
-    # start instances
-    if len(start_list) > 0:
-      ret = conn.start_instances(instance_ids=start_list, dry_run=False)
-      print "start_instances %s" % ret
+                        launch_time = dateutil.parser.parse(instance.launch_time)
 
-    # stop instances
-    if len(stop_list) > 0:
-      ret = conn.stop_instances(instance_ids=stop_list, dry_run=False)
-      print "stop_instances %s" % ret
+                        logger.debug("region: %s name: %s  id: %s launch: %s state: %s start_sched: %s stop_sched: %s",
+                                     region.name, name, instance.id, instance.launch_time, state, start_sched, stop_sched)
 
-  # most likely will get exception on new beta region and gov cloud
-  except Exception as e:
-    print 'Exception error in %s: %s' % (region.name, e.message)
+                        try:
+                            # queue up instances that have the start time falls between now and the next 30 minutes
+                            if start_sched and state == "stopped" and time_to_start(start_sched, now):
+                                logger.info("Starting instance: %s (%s)", name, instance.id)
+                                start_list.append(instance.id)
+                        except ValueError as ve:
+                            logger.error("Invalid auto:start tag on instance %s (%s): '%s' (%s)", name, instance.id, start_sched, e)
+
+                        try:
+                            # queue up instances that have the stop time falls between 30 minutes ago and now
+                            if stop_sched and state == "running" and time_to_stop(stop_sched, now, launch_time):
+                                logger.info("Stopping instance: %s (%s)", name, instance.id)
+                                stop_list.append(instance.id)
+                        except ValueError as ve:
+                            logger.error("Invalid auto:stop tag on instance %s (%s): '%s' (%s)", name, instance.id, stop_sched, e)
+
+                # start instances
+                if start_list and not args.dry_run:
+                    ret = conn.start_instances(instance_ids=start_list, dry_run=False)
+                    logger.info("start_instances %s", ret)
+
+                    # Check for any ELBs that need to be updated
+                    elb_conn = boto.ec2.elb.connect_to_region(region.name)
+                    load_balancers = elb_conn.get_all_load_balancers()
+                    for load_balancer in load_balancers:
+                        for elb_instance in load_balancer.instances:
+                            if elb_instance.id in start_list:
+                                if (not slept):
+                                    # Sleep to increase chances of instances properly re-registering with ELB
+                                    sleep(5)
+                                    slept = True
+                                logger.info("Re-registering instance %s in elastic load balancer %s", elb_instance.id, load_balancer.name)
+                                load_balancer.deregister_instances([elb_instance.id])
+                                load_balancer.register_instances([elb_instance.id])
+
+                # stop instances
+                if stop_list and not args.dry_run:
+                    ret = conn.stop_instances(instance_ids=stop_list, dry_run=False)
+                    logger.info("stop_instances %s", ret)
+
+            except Exception as e:
+                logger.error("Exception error in %s: %s", region.name, e)
+
+    logger.info("Run complete with %d instances evaluated.", instances)

--- a/ec2_operator.py
+++ b/ec2_operator.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
                                 logger.info("Starting instance: %s (%s)", name, instance.id)
                                 start_list.append(instance.id)
                         except ValueError as ve:
-                            logger.error("Invalid auto:start tag on instance %s (%s): '%s' (%s)", name, instance.id, start_sched, e)
+                            logger.error("Invalid auto:start tag on instance %s (%s): '%s' (%s)", name, instance.id, start_sched, ve)
 
                         try:
                             # queue up instances that have the stop time falls between 30 minutes ago and now
@@ -111,7 +111,7 @@ if __name__ == "__main__":
                                 logger.info("Stopping instance: %s (%s)", name, instance.id)
                                 stop_list.append(instance.id)
                         except ValueError as ve:
-                            logger.error("Invalid auto:stop tag on instance %s (%s): '%s' (%s)", name, instance.id, stop_sched, e)
+                            logger.error("Invalid auto:stop tag on instance %s (%s): '%s' (%s)", name, instance.id, stop_sched, ve)
 
                 # start instances
                 if start_list and not args.dry_run:


### PR DESCRIPTION
Features:
- Added support for timestamped logging with configuration (file, output level, rotation, etc) via command line arguments to avoid needing a configuration file
- Added --dry-run option
- Start/stop windows are now configurable and changed defaults
- Do not re-stop an instance that has been started since the stop window began. This stops people from having to fight the script if they wanted to restart an instance that was shut down on them.
- Iterate through all Elastic Load Balancers in the region and, if an instance being started was registered to one, pause, de-register it, then re-register it to make sure the instances come back online in the ELB. Otherwise, instances typically remained dead in ELBs despite being started back up.

Bug fixes:
- A run at the exact window time would fail to start or stop instances, thus making the windows required. It should now work with no window as long as the start/stop tags match up with cron intervals (e.g. on 5 minute boundaries)

Code changes:
- Separated, simplified, and clarified time to action logic
- Added a simple unit test to confirm time to action logic functionality
- Skip cn-north-1, us-gov-west-1 regions to avoid superfluous errors. This could be handled better, patches welcome.
- Don't swallow potentially useful exceptions.

These improvements graciously donated by TASER's Evidence.com team. Join us: https://www.evidence.com/careers
